### PR TITLE
fix typo in zswap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # wsl2-kernel-zram-zswap
 
-WSL2 kernel with zram and zwap.
+WSL2 kernel with zram and zswap.
 
 Tested on Ubuntu 22.04 with kernel 5.15.167.4-microsoft-standard-WSL2.
 


### PR DESCRIPTION
This pull request includes a small correction to the `README.md` file. The change fixes a typo in the description by replacing "zwap" with "zswap" for clarity.